### PR TITLE
Remove 'id' from '_source' when index to elasticsearch

### DIFF
--- a/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/DataLineItemEntity.java
+++ b/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/DataLineItemEntity.java
@@ -96,6 +96,7 @@ public class DataLineItemEntity extends ESEntity {
     private BigDecimal ele_freight;
     private BigDecimal ele_insurance;
 
+
     @Override
     public String getId() {
         return id;

--- a/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/ESEntity.java
+++ b/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/ESEntity.java
@@ -19,4 +19,6 @@ public class ESEntity {
         this.id = id;
     }
 
+
+
 }

--- a/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/Key.java
+++ b/es5xwriter/src/main/java/com/alibaba/datax/plugin/writer/es5xwriter/Key.java
@@ -23,6 +23,12 @@ public final class Key {
     public final static String esClusterPort = "esClusterPort";
 
     /*
+     * @name:  esClusterPort
+     * @description:  elastic search cluster port
+    */
+    public final static String esEnableSniff = "esEnableSniff";
+
+    /*
      * @name: esIndex
      * @description:  elastic search index
      */

--- a/es5xwriter/src/main/resources/plugin.json
+++ b/es5xwriter/src/main/resources/plugin.json
@@ -6,5 +6,5 @@
     "mechanism": "use datax framework to transport data to elasticsearch.",
     "warn": ""
   },
-  "developer": "xxx"
+  "developer": "lunatictwo"
 }

--- a/es5xwriter/src/main/resources/plugin_job_template.json
+++ b/es5xwriter/src/main/resources/plugin_job_template.json
@@ -4,6 +4,7 @@
     "esClusterName": "",
     "esClusterIP": "192.168.0.2",
     "esClusterPort": "9300",
+    "esEnableSniff": false,
     "esIndex": "user",
     "esType": "student",
     "attributeNameString": "id,column1,column2,column3",


### PR DESCRIPTION
remove 'id' from '_source' when index to elasticsearch, you don't need 'id' fields when you have '_id'.